### PR TITLE
Remove outdated Early Access information from readme.md.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,9 +24,6 @@ Once installed, Junie will automatically:
 Junie will operate in the environment defined by your `devcontainer.json`, so this file must describe an environment where the project can be built and tests can be run successfully.
 We provide a default devcontainer, but it may not suit your specific needs; you may need to adjust it.  For more information about devcontainers, see: https://containers.dev/overview.
 
-> Junie is currently in closed Early Access.  
-> To join, please visit our [Discord](https://jb.gg/junie/github) or ask to be added to the whitelist.
-
 ---
 
 ### 📝 Manual Setup (optional)


### PR DESCRIPTION
Junie has completed its closed Early Access period and is now GA, so this outdated information has been removed from the `readme.md`.