### PR TITLE
feat: support array for runs-on

### DIFF
--- a/.github/workflows/ej-issue.yml
+++ b/.github/workflows/ej-issue.yml
@@ -24,7 +24,7 @@ on:
         required: true
       runs-on:
         description: "Which runner use to run junie"
-        type: string
+        type: [string, array]
         default: "ubuntu-latest"
         required: false
 


### PR DESCRIPTION
In some cases, you need to specify an array for `runs-on`. For example, if you want to use self-hosted runners instead of GitHub runners: (since having multiple self-hosted runners needs tagging; we want to run it on our Linux containers, not the macOS ones we use to build apps for example)

```yaml
jobs:
  call-workflow-passing-data:
    uses: jetbrains-junie/junie-workflows/.github/workflows/ej-issue.yml@main
    with:
      runs-on: [ self-hosted, Linux, X64 ]
      workflow_params: ${{ inputs.workflow_params }}
```

Currently, we get this error:
```
Schema validation: Incompatible types.
Required one of: boolean, number, string. Actual: array. 
```

So that's why I added `array` in the workflow. Thank you!
